### PR TITLE
Fix client connection deadlocks

### DIFF
--- a/pkg/central/central.go
+++ b/pkg/central/central.go
@@ -270,7 +270,7 @@ func startMonitoring(addr string) {
 	http.Handle("/metrics", prometheus.Handler())
 	redisMaxConn.Set(float64(redisPool.MaxActive))
 	go func() {
-		tick := time.NewTicker(time.Duration(1 * time.Second))
+		tick := time.NewTicker(1 * time.Second)
 		for range tick.C {
 			if redisPool == nil {
 				redisActiveConn.Set(0)

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -895,10 +895,11 @@ func testSocks5Internet(addr string) (err error) {
 		Transport: &http.Transport{
 			Dial:                  dialSocksProxy,
 			DisableKeepAlives:     true,
-			ResponseHeaderTimeout: time.Duration(time.Second * 5),
+			ResponseHeaderTimeout: 10 * time.Second,
 		},
+		Timeout: 20 * time.Second,
 	}
-	resp, err := httpClient.Get("http://ip.appspot.com")
+	resp, err := httpClient.Get("https://alkasir.com/ping")
 	if err != nil {
 		return
 	}

--- a/pkg/client/internal/config/config.go
+++ b/pkg/client/internal/config/config.go
@@ -233,7 +233,7 @@ func (l *localSettings) ApplicationUpdateDuration() time.Duration {
 	if !l.ClientAutoUpdate {
 		return time.Duration(0)
 	}
-	return time.Duration(time.Hour * 2)
+	return 2 * time.Hour
 }
 
 // BlocklistUpdateDuration returns BlocklistUpdateInterval as a duration.
@@ -241,7 +241,7 @@ func (l *localSettings) BlocklistUpdateDuration() time.Duration {
 	if !l.BlocklistAutoUpdate {
 		return time.Duration(0)
 	}
-	return time.Duration(time.Hour * 6)
+	return 6 * time.Hour
 }
 
 // settingsTemplate is default when there is no config file or if it's broken.

--- a/pkg/client/upgradebin.go
+++ b/pkg/client/upgradebin.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/alkasir/alkasir/pkg/service"
 	"github.com/alkasir/alkasir/pkg/shared"
@@ -92,7 +93,7 @@ func upgradeBinaryCheck(diffsBaseURL string) error {
 	}
 	lg.Warningf("found update %+v", res)
 
-	httpclient, err := service.NewTransportHTTPClient()
+	httpclient, err := service.NewTransportHTTPClient(2 * time.Hour)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/upgradeblocklist.go
+++ b/pkg/client/upgradeblocklist.go
@@ -24,7 +24,7 @@ func StartBlocklistUpgrader() {
 	uChecker, _ := NewUpdateChecker("blocklist")
 	service.AddListener(connectionEventListener)
 	currentCountry := clientconfig.Get().Settings.Local.CountryCode
-	checkCountrySettingC := time.NewTicker(time.Duration(2 * time.Second))
+	checkCountrySettingC := time.NewTicker(2 * time.Second)
 	defer checkCountrySettingC.Stop()
 loop:
 	for {

--- a/pkg/client/util.go
+++ b/pkg/client/util.go
@@ -4,12 +4,13 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"time"
 
-	"github.com/thomasf/lg"
 	"github.com/alkasir/alkasir/pkg/central/client"
 	"github.com/alkasir/alkasir/pkg/client/internal/config"
 	"github.com/alkasir/alkasir/pkg/service"
 	"github.com/alkasir/alkasir/pkg/shared"
+	"github.com/thomasf/lg"
 )
 
 // deprecated, function moved to shared package
@@ -39,7 +40,7 @@ func NewRestClient() (*client.Client, error) {
 		return client.NewClient(apiurl, nil), nil
 	}
 
-	httpclient, err := service.NewTransportHTTPClient()
+	httpclient, err := service.NewTransportHTTPClient(time.Minute)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/shared/publicip.go
+++ b/pkg/shared/publicip.go
@@ -50,9 +50,8 @@ func GetPublicIPAddr() net.IP {
 		publicIP.hasIP.Add(1)
 
 		go func() {
-			timeout := time.Duration(10 * time.Second)
 			client := http.Client{
-				Timeout:   timeout,
+				Timeout:   15 * time.Second,
 				Transport: v4Transport,
 			}
 			var services []string = make([]string, 0)


### PR DESCRIPTION
I would have liked to rewrite this but since were close to public launch
I modified as little as possible instead to reduce the risk of new bugs.

- Add request timeouts for all client -> central HTTP clients
- Reduce connection manager defaultTransport locking times.
- Give transportOK status bool it's own mutex.

fixes #40 